### PR TITLE
ci: add arm64 build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,3 +91,34 @@ jobs:
           else
             make -j"$(nproc)"
           fi
+  build-arm64:
+    name: arm64 / Qt 6.7.0
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config libglu1-mesa-dev libegl1-mesa-dev libxkbcommon-dev
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: 6.7.0
+          host: linux_arm64
+          target: desktop
+          arch: linux_gcc_arm64
+          modules: qtcharts
+          install-deps: false
+          cache: true
+      - name: Show qmake version
+        run: qmake -v
+      - name: Configure project
+        run: |
+          mkdir -p build
+          cd build
+          qmake ../src/xenadminqt.pro
+      - name: Build project
+        run: |
+          cd build
+          make -j"$(nproc)"


### PR DESCRIPTION
Adds a native arm64 build job using the GitHub-hosted `ubuntu-24.04-arm` runner.

The existing x86_64 jobs use `jurplel/install-qt-action@v3`, which predates arm64 support. This job uses v4, which added the `linux_arm64` host (requires Qt 6.7.0+, the first version with official arm64 binaries on download.qt.io).

FreeRDP is not included: `freerdp3-dev` is only available for `amd64` on Ubuntu 24.04. RDP support will be disabled on arm64 until Ubuntu 26.04 runners are available, at which point it can be added back with a one-line runner change.

Validated on a fork before opening this PR.

## Why arm64 matters for XenAdminQt

XenAdminQt runs on the administrator's workstation, not the managed servers. Linux arm64 workstations are increasingly common:

- AWS Graviton, Ampere Altra, and similar arm64 cloud instances are widely used as jump hosts or bastion nodes from which admins manage infrastructure.
- ARM-based Linux laptops and desktops are growing (Snapdragon X, Raspberry Pi 5 as a thin client, etc.).