### PR TITLE
ci: bump install-qt-action to v4 for all matrix jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
             apt-get install -y build-essential pkg-config freerdp2-dev libwinpr2-dev mesa-common-dev libglu1-mesa-dev libegl1 libxkbcommon0
           fi
       - name: Install Qt
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
           version: ${{ matrix.qt_version }}
           host: ${{ matrix.host }}


### PR DESCRIPTION
Suggested in #22. The arm64 job already used v4; this brings the remaining six matrix entries (Ubuntu/Debian/macOS with Qt 5.15.2 and 6.6.2) in line with it.

No parameter changes needed; the upgrade guide confirms `host: linux`, `host: mac`, `arch: gcc_64` and `arch: clang_64` are all still valid in v4.