### PR TITLE
ci: add arm64 and riscv64 Debian release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to upload assets to (e.g. v0.0.6-alpha)'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  package-riscv64-deb:
+    name: riscv64 / Debian package
+    runs-on: ubuntu-24.04-riscv
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Fix dpkg database (RISE runner workaround)
+        run: |
+          if [ ! -d /var/lib/dpkg ]; then
+            sudo mkdir -p /var/lib/dpkg/info \
+              /var/lib/dpkg/updates /var/lib/dpkg/parts
+            sudo touch /var/lib/dpkg/status
+          fi
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential debhelper dpkg-dev pkg-config \
+            qt6-base-dev qt6-charts-dev \
+            libglu1-mesa-dev libegl1-mesa-dev libxkbcommon-dev
+
+      - name: Determine version and tag
+        id: meta
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          VERSION=$(echo "$TAG" | sed 's/^v//; s/[-+].*//')
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build Debian package
+        run: |
+          bash packaging/package-deb.sh \
+            --version "${{ steps.meta.outputs.version }}"
+
+      - name: Upload .deb assets to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          find packaging/output -name "*.deb" | while read -r deb; do
+            gh release upload "$RELEASE_TAG" "$deb" \
+              --repo "$GITHUB_REPOSITORY" \
+              --clobber
+          done
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,22 @@ permissions:
   contents: write
 
 jobs:
-  package-riscv64-deb:
-    name: riscv64 / Debian package
-    runs-on: ubuntu-24.04-riscv
+  package-deb:
+    name: ${{ matrix.arch }} / Debian package
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+          - arch: riscv64
+            runner: ubuntu-24.04-riscv
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
 
       - name: Fix dpkg database (RISE runner workaround)
+        if: matrix.arch == 'riscv64'
         run: |
           if [ ! -d /var/lib/dpkg ]; then
             sudo mkdir -p /var/lib/dpkg/info \

--- a/packaging/package-deb.sh
+++ b/packaging/package-deb.sh
@@ -222,8 +222,10 @@ mkdir -p "$OUTPUT_DIR"
 DEB_FILES=()
 collect_debs() {
     local base_dir="$1"
+    local native_arch
+    native_arch=$(dpkg --print-architecture 2>/dev/null || echo "amd64")
     local arch
-    for arch in amd64 all; do
+    for arch in "$native_arch" all; do
         [ -f "$base_dir/${APP_NAME}_${DEB_VERSION}_${arch}.deb" ] && DEB_FILES+=("$base_dir/${APP_NAME}_${DEB_VERSION}_${arch}.deb")
         [ -f "$base_dir/${APP_NAME}-dbgsym_${DEB_VERSION}_${arch}.deb" ] && DEB_FILES+=("$base_dir/${APP_NAME}-dbgsym_${DEB_VERSION}_${arch}.deb")
     done


### PR DESCRIPTION
Two changes:

**1. Fix `collect_debs()` to use the native build arch**

`packaging/package-deb.sh` looks for `*_amd64.deb` regardless of
which arch ran the build. On arm64 or riscv64, dpkg-buildpackage
produces `*_arm64.deb` or `*_riscv64.deb` and the script never
finds them, so the upload step silently does nothing. Fix uses
`dpkg --print-architecture` with an `amd64` fallback, so existing
amd64 workflows are unaffected.

**2. New `release.yml` for arm64 and riscv64 Debian packages**

I saw you removed riscv64 from `build.yml` because there were no
runners. Fair, I'm not reverting that here.

The RISE project (riseproject.dev) provides free native riscv64
runners for open-source projects via a GitHub App
(github.com/apps/rise-risc-v-runners), label `ubuntu-24.04-riscv`.
For arm64, this uses the standard GitHub-hosted `ubuntu-24.04-arm`.

Validated on a BananaPI F3 (SpaceMiT K1, rv64gc, 8 cores):
- `dpkg-buildpackage` produces a correct `riscv64` .deb
- Package installs, `xenadmin-qt --version` reports 0.0.6
- ELF header confirms native rv64gc binary

If non-amd64 packages aren't a priority, feel free to close. Just
wanted to surface that the runner gap is filled for riscv64, and
arm64 gets it for free with the same workflow.